### PR TITLE
Proposal: support for certificates for domains with zones in different Azure resource groups

### DIFF
--- a/certbot_azure/dns_azure.py
+++ b/certbot_azure/dns_azure.py
@@ -160,7 +160,7 @@ class _AzureClient(object):
                 if zone_in_group.name == zone:
                     return resource_group
 
-        return None
+        raise errors.PluginError('Error finding {0} zone in provided resource groups'.format(zone))
 
     def _find_managed_zone(self, domain):
         """


### PR DESCRIPTION
## Current state

Currently, it is not possible to generate a single certificate for two domains (from two different Azure DNS zones) in two different resource groups, because of how `--dns-azure-resource-group` option works.

Example on how DNS zones might be organized in Azure:

domain1.com zone in `group1` resource group
domain2.com zone in `group2` resource group

## My proposal

Accept multiple resource groups (comma separated) for `--dns-azure-resource-group`. During verification, find resource group for a particular zone when creating / deleting `TXT` record.

Example usage after the change:

```bash
certbot certonly \
 -d '*.domain1.com' \
 -d '*.domain2.com' \
 -a dns-azure \
 --dns-azure-credentials credentials.json \
 --dns-azure-resource-group group1,group2
```

----


**This is a minimal working version.** If (from the perspective of an end user) this change is ok, I will refactor the code and add tests / documentation if needed.
